### PR TITLE
Move click track button for better UI

### DIFF
--- a/cadence/app.js
+++ b/cadence/app.js
@@ -2157,34 +2157,36 @@ function renderSongCatalog() {
     return;
   }
   
-  state.songs.forEach((song) => {
-    const div = document.createElement("div");
-    div.className = "card set-song-card";
-    div.innerHTML = `
-      <div style="display: flex; justify-content: space-between; align-items: start;">
-        <div style="flex: 1;">
-          <h4 class="song-title" style="margin: 0 0 0.5rem 0;">${escapeHtml(song.title)}</h4>
-          <div class="song-meta-text" style="display: flex; gap: 1rem;">
-            ${song.bpm ? `<span>BPM: ${song.bpm}</span>` : ''}
-            ${song.song_key ? `<span>Key: ${song.song_key}</span>` : ''}
-            ${song.time_signature ? `<span>Time: ${escapeHtml(song.time_signature)}</span>` : ''}
-            ${song.duration_seconds ? `<span>Duration: ${formatDuration(song.duration_seconds)}</span>` : ''}
+    state.songs.forEach((song) => {
+      const div = document.createElement("div");
+      div.className = "card set-song-card";
+      div.innerHTML = `
+        <div class="set-song-header song-card-header">
+          <div class="set-song-info">
+            <h4 class="song-title" style="margin: 0 0 0.5rem 0;">${escapeHtml(song.title)}</h4>
+            <div class="song-meta-row">
+              <div class="song-meta-text">
+                ${song.bpm ? `<span>BPM: ${song.bpm}</span>` : ''}
+                ${song.song_key ? `<span>Key: ${song.song_key}</span>` : ''}
+                ${song.time_signature ? `<span>Time: ${escapeHtml(song.time_signature)}</span>` : ''}
+                ${song.duration_seconds ? `<span>Duration: ${formatDuration(song.duration_seconds)}</span>` : ''}
+              </div>
+              ${song.bpm ? `
+              <button class="btn small ghost click-track-btn" data-song-id="${song.id}" data-bpm="${song.bpm}" title="Click Track">
+                ${state.metronome.isPlaying && state.metronome.bpm === song.bpm ? '⏸ Stop' : '▶ Click'}
+              </button>
+              ` : ''}
+            </div>
+          </div>
+          <div class="set-song-actions song-card-actions">
+            <button class="btn small secondary view-song-details-catalog-btn" data-song-id="${song.id}">View Details</button>
+            ${state.profile?.can_manage ? `
+            <button class="btn small secondary edit-song-btn" data-song-id="${song.id}">Edit</button>
+            <button class="btn small ghost delete-song-btn" data-song-id="${song.id}">Delete</button>
+            ` : ''}
           </div>
         </div>
-        <div style="display: flex; gap: 0.5rem; align-items: center;">
-          <button class="btn small secondary view-song-details-catalog-btn" data-song-id="${song.id}">View Details</button>
-          ${song.bpm ? `
-          <button class="btn small ghost click-track-btn" data-song-id="${song.id}" data-bpm="${song.bpm}" title="Click Track">
-            ${state.metronome.isPlaying && state.metronome.bpm === song.bpm ? '⏸ Stop' : '▶ Click'}
-          </button>
-          ` : ''}
-          ${state.profile?.can_manage ? `
-          <button class="btn small secondary edit-song-btn" data-song-id="${song.id}">Edit</button>
-          <button class="btn small ghost delete-song-btn" data-song-id="${song.id}">Delete</button>
-          ` : ''}
-        </div>
-      </div>
-    `;
+      `;
     
     const viewDetailsBtn = div.querySelector(".view-song-details-catalog-btn");
     if (viewDetailsBtn) {

--- a/cadence/index.html
+++ b/cadence/index.html
@@ -360,14 +360,11 @@
 
       <template id="song-item-template">
         <div class="set-song-card">
-        <div class="drag-handle" title="Drag to reorder" style="display: none;">⋮⋮</div>
+          <div class="drag-handle" title="Drag to reorder" style="display: none;">⋮⋮</div>
           <div class="set-song-header" style="padding-left: 2.5rem;">
             <div class="set-song-info">
               <h4 class="song-title"></h4>
-              <div class="song-meta-row">
-                <p class="song-meta"></p>
-                <button class="btn small ghost click-track-btn hidden" data-bpm="" title="Click Track">▶ Click</button>
-              </div>
+              <p class="song-meta"></p>
             </div>
             <div class="set-song-actions">
               <button class="btn small secondary view-song-details-btn" data-song-id="">View Details</button>
@@ -375,9 +372,9 @@
               <button class="btn small ghost remove-song-from-set-btn hidden" data-set-song-id="">Remove</button>
             </div>
           </div>
-        <p class="song-notes"></p>
-        <div class="assignments"></div>
-      </div>
+          <p class="song-notes"></p>
+          <div class="assignments"></div>
+        </div>
     </template>
 
     <template id="assignment-pill-template">

--- a/cadence/index.html
+++ b/cadence/index.html
@@ -358,21 +358,23 @@
       </article>
     </template>
 
-    <template id="song-item-template">
-      <div class="set-song-card">
+      <template id="song-item-template">
+        <div class="set-song-card">
         <div class="drag-handle" title="Drag to reorder" style="display: none;">⋮⋮</div>
-        <div class="set-song-header" style="padding-left: 2.5rem;">
-          <div>
-            <h4 class="song-title"></h4>
-            <p class="song-meta"></p>
+          <div class="set-song-header" style="padding-left: 2.5rem;">
+            <div class="set-song-info">
+              <h4 class="song-title"></h4>
+              <div class="song-meta-row">
+                <p class="song-meta"></p>
+                <button class="btn small ghost click-track-btn hidden" data-bpm="" title="Click Track">▶ Click</button>
+              </div>
+            </div>
+            <div class="set-song-actions">
+              <button class="btn small secondary view-song-details-btn" data-song-id="">View Details</button>
+              <button class="btn small ghost edit-set-song-btn hidden" data-set-song-id="">Edit</button>
+              <button class="btn small ghost remove-song-from-set-btn hidden" data-set-song-id="">Remove</button>
+            </div>
           </div>
-          <div style="display: flex; gap: 0.5rem; align-items: center;">
-            <button class="btn small secondary view-song-details-btn" data-song-id="">View Details</button>
-            <button class="btn small ghost click-track-btn hidden" data-bpm="" title="Click Track">▶ Click</button>
-            <button class="btn small ghost edit-set-song-btn hidden" data-set-song-id="">Edit</button>
-            <button class="btn small ghost remove-song-from-set-btn hidden" data-set-song-id="">Remove</button>
-          </div>
-        </div>
         <p class="song-notes"></p>
         <div class="assignments"></div>
       </div>

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -331,24 +331,6 @@ main {
   font-size: 0.9rem;
 }
 
-.song-meta-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-top: 0.25rem;
-  flex-wrap: wrap;
-}
-
-.song-meta-row .song-meta,
-.song-meta-row .song-meta-text {
-  margin: 0;
-  flex: 1;
-}
-
-.song-meta-row .click-track-btn {
-  flex-shrink: 0;
-}
-
 .song-description-text {
   color: var(--text-secondary);
   margin: 0.5rem 0 0 0;
@@ -734,6 +716,37 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.song-click-track {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.song-click-track-info {
+  flex: 1;
+  min-width: 200px;
+}
+
+.song-click-track-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.song-click-track-description {
+  margin: 0.25rem 0 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
 }
 
 .assignment-row {

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -298,6 +298,20 @@ main {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.set-song-info {
+  flex: 1;
+  min-width: 200px;
+}
+
+.set-song-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .song-title {
@@ -315,6 +329,24 @@ main {
 .song-meta-text {
   color: var(--text-secondary);
   font-size: 0.9rem;
+}
+
+.song-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.song-meta-row .song-meta,
+.song-meta-row .song-meta-text {
+  margin: 0;
+  flex: 1;
+}
+
+.song-meta-row .click-track-btn {
+  flex-shrink: 0;
 }
 
 .song-description-text {


### PR DESCRIPTION
Move the Click track button into song details on set and song panes for improved aesthetics and contextual grouping with song metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f0d2de7-7d30-4740-afcb-cb32edf46496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f0d2de7-7d30-4740-afcb-cb32edf46496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the click track control into the song details modal and updates song/set card structure and styles.
> 
> - **UI/Behavior**:
>   - Remove `click-track-btn` from set song items and song catalog cards; add a dedicated click track section in the song details modal with metronome state syncing (`toggleMetronome`, `updateClickTrackButtons`).
> - **Song Cards & Templates**:
>   - Refactor headers into `set-song-info` and `set-song-actions` in `song-item-template` and song catalog items; keep primary actions (View/Edit/Delete) in actions area.
> - **Styles**:
>   - Add responsive layout for `set-song-header`, new classes `set-song-info`, `set-song-actions`.
>   - Introduce `song-click-track` styles (container, info, title, description) for the modal section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79943bc9ba9e989484d0a50af38d7d6ee4889194. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->