### PR TITLE
Assignment chip song details

### DIFF
--- a/cadence/app.js
+++ b/cadence/app.js
@@ -3118,6 +3118,10 @@ function renderSetCard(set, container) {
               ? (setSong.song?.title || "Unknown Song")
               : (setSong.title || "Unknown Section");
             userAssignments.push({
+              setSongId: setSong.id,
+              songId: setSong.song_id || null,
+              song: setSong.song || null,
+              selectedKey: setSong.key || null,
               songTitle,
               role: assignment.role,
                   sequenceOrder: setSong.sequence_order ?? 0,
@@ -3145,6 +3149,22 @@ function renderSetCard(set, container) {
           pill.textContent = assignment.role;
         } else {
         pill.textContent = `${assignment.songTitle} - ${assignment.role}`;
+          // Clicking a "Your Sets" assignment pill should open the set and the song details
+          pill.style.cursor = "pointer";
+          if (assignment.setSongId) pill.dataset.setSongId = String(assignment.setSongId);
+          if (assignment.songId) pill.dataset.songId = String(assignment.songId);
+          if (assignment.selectedKey) pill.dataset.selectedKey = assignment.selectedKey;
+          pill.addEventListener("click", async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            showSetDetail(set);
+            // Only open details for real songs (not sections)
+            if (assignment.songId) {
+              const songForModal =
+                assignment.song || { id: assignment.songId, title: assignment.songTitle };
+              await openSongDetailsModal(songForModal, assignment.selectedKey || null);
+            }
+          });
         }
         rolesWrapper.appendChild(pill);
         pills.push(pill);


### PR DESCRIPTION
Adds click functionality to assignment chips in "Your Sets" to open the corresponding set and song details.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c3c889c-bb41-4055-ba44-163e34e2b0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c3c889c-bb41-4055-ba44-163e34e2b0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Per-song assignment pills in "Your Sets" are now clickable to open the set and, for songs, the song details modal (with selected key).
> 
> - **UI/Interactions (cadence/app.js)**:
>   - Add click handling to per-song assignment pills in `Your Sets` to:
>     - Open the parent set via `showSetDetail(set)`.
>     - For real songs, open `openSongDetailsModal` with the correct `selectedKey`.
>   - Enrich pill data with `setSongId`, `songId`, `song`, and `selectedKey`; store as `data-*` attrs and set pointer cursor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1132550128dce0db7cea9aaf293e81c46eb4112f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->