### PR TITLE
Cursor/song title album tint 2aa8

### DIFF
--- a/cadence/app.js
+++ b/cadence/app.js
@@ -16037,20 +16037,26 @@ const loadImageWithFallback = async (url) => {
 const loadingAlbumArt = new Set();
 
 function setSongDetailsTitleTint(content, hexColor = null) {
+  if (!content) return;
   const songTitleEl = content?.querySelector?.(".song-details-header-content .song-details-title");
-  if (!songTitleEl) return;
 
   if (!hexColor || !/^#[0-9a-fA-F]{6}$/.test(hexColor)) {
-    songTitleEl.classList.remove("song-details-title--album-tinted");
-    songTitleEl.style.removeProperty("--song-title-tint-rgb");
+    if (songTitleEl) {
+      songTitleEl.classList.remove("song-details-title--album-tinted");
+    }
+    content.classList.remove("song-details-content--album-tinted");
+    content.style.removeProperty("--song-title-tint-rgb");
     return;
   }
 
   const r = parseInt(hexColor.slice(1, 3), 16);
   const g = parseInt(hexColor.slice(3, 5), 16);
   const b = parseInt(hexColor.slice(5, 7), 16);
-  songTitleEl.style.setProperty("--song-title-tint-rgb", `${r} ${g} ${b}`);
-  songTitleEl.classList.add("song-details-title--album-tinted");
+  content.style.setProperty("--song-title-tint-rgb", `${r} ${g} ${b}`);
+  content.classList.add("song-details-content--album-tinted");
+  if (songTitleEl) {
+    songTitleEl.classList.add("song-details-title--album-tinted");
+  }
 }
 
 /**

--- a/cadence/app.js
+++ b/cadence/app.js
@@ -16036,6 +16036,23 @@ const loadImageWithFallback = async (url) => {
 // Track which songs are currently loading album art to prevent duplicate calls
 const loadingAlbumArt = new Set();
 
+function setSongDetailsTitleTint(content, hexColor = null) {
+  const songTitleEl = content?.querySelector?.(".song-details-header-content .song-details-title");
+  if (!songTitleEl) return;
+
+  if (!hexColor || !/^#[0-9a-fA-F]{6}$/.test(hexColor)) {
+    songTitleEl.classList.remove("song-details-title--album-tinted");
+    songTitleEl.style.removeProperty("--song-title-tint-rgb");
+    return;
+  }
+
+  const r = parseInt(hexColor.slice(1, 3), 16);
+  const g = parseInt(hexColor.slice(3, 5), 16);
+  const b = parseInt(hexColor.slice(5, 7), 16);
+  songTitleEl.style.setProperty("--song-title-tint-rgb", `${r} ${g} ${b}`);
+  songTitleEl.classList.add("song-details-title--album-tinted");
+}
+
 /**
  * Display album art in the song details modal
  * @param {HTMLElement} content - The modal content element
@@ -16095,8 +16112,10 @@ async function displayAlbumArt(content, albumArtData, song) {
 
         // Use a more vibrant shadow with the extracted color
         img.style.boxShadow = `0 12px 80px rgba(${r}, ${g}, ${b}, ${mainOpacity}), 0 6px 80px rgba(${r}, ${g}, ${b}, ${secondaryOpacity})`;
+        setSongDetailsTitleTint(content, vibrantColor);
         console.log('Applied vibrant color shadow:', vibrantColor);
       } else {
+        setSongDetailsTitleTint(content, null);
         console.log('No vibrant color found, using default shadow');
       }
     } catch (err) {
@@ -18122,6 +18141,7 @@ function showSongAlbumArtLoadingPlaceholder(content) {
 
   if (imgEl) imgEl.style.display = "none";
   if (noImageEl) noImageEl.classList.add("hidden");
+  setSongDetailsTitleTint(content, null);
 }
 
 function collapseSongAlbumArt(content) {
@@ -18145,6 +18165,7 @@ function collapseSongAlbumArt(content) {
       container.style.display = "none";
     }
   }, 380);
+  setSongDetailsTitleTint(content, null);
 }
 
 async function refreshOpenSongDetailsAlbumArtFromIndexRefresh(updatedRowsById) {
@@ -18198,6 +18219,7 @@ function showSongAlbumArtNoImagePlaceholder(content) {
   }
   if (imgEl) imgEl.style.display = "none";
   if (noImageEl) noImageEl.classList.remove("hidden");
+  setSongDetailsTitleTint(content, null);
 }
 
 async function openSectionDetailsModal(setSong) {

--- a/cadence/app.js
+++ b/cadence/app.js
@@ -16036,6 +16036,88 @@ const loadImageWithFallback = async (url) => {
 // Track which songs are currently loading album art to prevent duplicate calls
 const loadingAlbumArt = new Set();
 
+function parseHexOrRgbColor(colorValue) {
+  if (!colorValue || typeof colorValue !== "string") return null;
+  const color = colorValue.trim();
+  if (!color) return null;
+
+  const hexMatch = color.match(/^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i);
+  if (hexMatch) {
+    const hex = hexMatch[1];
+    if (hex.length === 3 || hex.length === 4) {
+      return {
+        r: parseInt(hex[0] + hex[0], 16),
+        g: parseInt(hex[1] + hex[1], 16),
+        b: parseInt(hex[2] + hex[2], 16),
+      };
+    }
+    // Ignore alpha component when present.
+    return {
+      r: parseInt(hex.slice(0, 2), 16),
+      g: parseInt(hex.slice(2, 4), 16),
+      b: parseInt(hex.slice(4, 6), 16),
+    };
+  }
+
+  const rgbMatch = color.match(/^rgba?\(\s*([0-9.]+)[,\s]+([0-9.]+)[,\s]+([0-9.]+)/i);
+  if (rgbMatch) {
+    return {
+      r: Math.max(0, Math.min(255, Math.round(Number(rgbMatch[1])))),
+      g: Math.max(0, Math.min(255, Math.round(Number(rgbMatch[2])))),
+      b: Math.max(0, Math.min(255, Math.round(Number(rgbMatch[3])))),
+    };
+  }
+
+  return null;
+}
+
+function rgbToHex({ r, g, b }) {
+  return `#${[r, g, b].map(v => v.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function getRelativeLuminance({ r, g, b }) {
+  const toLinear = (channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045
+      ? normalized / 12.92
+      : Math.pow((normalized + 0.055) / 1.055, 2.4);
+  };
+
+  const lr = toLinear(r);
+  const lg = toLinear(g);
+  const lb = toLinear(b);
+  return 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
+}
+
+function isDarkSongDetailsContext() {
+  const rootStyles = getComputedStyle(document.documentElement);
+  const bgPrimary = rootStyles.getPropertyValue("--bg-primary").trim();
+  const bgRgb = parseHexOrRgbColor(bgPrimary) || parseHexOrRgbColor(getComputedStyle(document.body).backgroundColor);
+  if (!bgRgb) return false;
+  return getRelativeLuminance(bgRgb) < 0.45;
+}
+
+function getReadableSongDetailsTint(hexColor) {
+  const rgb = parseHexOrRgbColor(hexColor);
+  if (!rgb) return hexColor;
+
+  // Preserve light mode behavior exactly; only normalize in dark contexts.
+  if (!isDarkSongDetailsContext()) return hexColor;
+
+  const luminance = getRelativeLuminance(rgb);
+  const minTintLuminance = 0.32;
+  if (luminance >= minTintLuminance) return hexColor;
+
+  // Lift very dark colors toward white so subtle text tint keeps contrast.
+  const blendTowardWhite = Math.min(0.65, Math.max(0.2, (minTintLuminance - luminance) / Math.max(minTintLuminance, 0.001)));
+  const boosted = {
+    r: Math.round(rgb.r + (255 - rgb.r) * blendTowardWhite),
+    g: Math.round(rgb.g + (255 - rgb.g) * blendTowardWhite),
+    b: Math.round(rgb.b + (255 - rgb.b) * blendTowardWhite),
+  };
+  return rgbToHex(boosted);
+}
+
 function setSongDetailsTitleTint(content, hexColor = null) {
   if (!content) return;
   const songTitleEl = content?.querySelector?.(".song-details-header-content .song-details-title");
@@ -16049,9 +16131,10 @@ function setSongDetailsTitleTint(content, hexColor = null) {
     return;
   }
 
-  const r = parseInt(hexColor.slice(1, 3), 16);
-  const g = parseInt(hexColor.slice(3, 5), 16);
-  const b = parseInt(hexColor.slice(5, 7), 16);
+  const readableTintHex = getReadableSongDetailsTint(hexColor);
+  const r = parseInt(readableTintHex.slice(1, 3), 16);
+  const g = parseInt(readableTintHex.slice(3, 5), 16);
+  const b = parseInt(readableTintHex.slice(5, 7), 16);
   content.style.setProperty("--song-title-tint-rgb", `${r} ${g} ${b}`);
   content.classList.add("song-details-content--album-tinted");
   if (songTitleEl) {

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -1,5 +1,6 @@
 :root {
   --accent-color: #ff7b51;
+  --song-title-tint-rgb: 255 255 255;
   --accent-light: color-mix(in srgb, var(--accent-color) 20%, black);
   --accent-lighter: color-mix(in srgb, var(--accent-color) 10%, black);
 
@@ -2108,6 +2109,14 @@ textarea {
   color: color-mix(in srgb, var(--text-primary) 94%, rgb(var(--song-title-tint-rgb, 255 255 255)) 6%);
 }
 
+.song-details-content.song-details-content--album-tinted .detail-label {
+  color: color-mix(in srgb, var(--text-muted) 92%, rgb(var(--song-title-tint-rgb, 255 255 255)) 8%);
+}
+
+.song-details-content.song-details-content--album-tinted .detail-value {
+  color: color-mix(in srgb, var(--text-primary) 95%, rgb(var(--song-title-tint-rgb, 255 255 255)) 5%);
+}
+
 .song-album-art-container {
   display: flex;
   justify-content: center;
@@ -2469,12 +2478,14 @@ textarea {
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 500;
+  transition: color 0.24s ease;
 }
 
 .detail-value {
   font-size: 1.25rem;
   color: var(--text-primary);
   font-weight: 600;
+  transition: color 0.24s ease;
 }
 
 .section-title {

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -2103,6 +2103,10 @@ textarea {
   color: var(--text-primary);
 }
 
+.song-details-title.song-details-title--album-tinted {
+  color: color-mix(in srgb, var(--text-primary) 94%, rgb(var(--song-title-tint-rgb, 255 255 255)) 6%);
+}
+
 .song-album-art-container {
   display: flex;
   justify-content: center;

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -2106,15 +2106,15 @@ textarea {
 }
 
 .song-details-title.song-details-title--album-tinted {
-  color: color-mix(in srgb, var(--text-primary) 94%, rgb(var(--song-title-tint-rgb, 255 255 255)) 6%);
+  color: color-mix(in srgb, var(--text-primary) 50%, rgb(var(--song-title-tint-rgb, 255 255 255)) 50%);
 }
 
 .song-details-content.song-details-content--album-tinted .detail-label {
-  color: color-mix(in srgb, var(--text-muted) 92%, rgb(var(--song-title-tint-rgb, 255 255 255)) 8%);
+  color: color-mix(in srgb, var(--text-muted) 50%, rgb(var(--song-title-tint-rgb, 255 255 255)) 50%);
 }
 
 .song-details-content.song-details-content--album-tinted .detail-value {
-  color: color-mix(in srgb, var(--text-primary) 95%, rgb(var(--song-title-tint-rgb, 255 255 255)) 5%);
+  color: color-mix(in srgb, var(--text-primary) 50%, rgb(var(--song-title-tint-rgb, 255 255 255)) 50%);
 }
 
 .song-album-art-container {

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -2101,6 +2101,7 @@ textarea {
   font-weight: 700;
   margin: 0 0 1.5rem 0;
   color: var(--text-primary);
+  transition: color 0.24s ease;
 }
 
 .song-details-title.song-details-title--album-tinted {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily UI styling and DOM/CSS variable updates in the song details modal. Risk is limited to visual regressions (contrast/readability across themes and browsers).
> 
> **Overview**
> Adds *album-art-driven text tinting* to the song details modal: when a vibrant color is extracted from album art, the title and metadata text now blend toward that color via a new `--song-title-tint-rgb` CSS variable and `song-details-*-album-tinted` classes.
> 
> Introduces color parsing/luminance utilities and a dark-mode readability guard that boosts very dark extracted colors before applying them. Tint state is explicitly reset when album art is loading, collapsed, missing, or when no vibrant color is found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4fa63321d48949240e9b0e215e1d8a81b459bc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->