### PR TITLE
Define shared song tint CSS variable in root

### DIFF
--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -1,5 +1,6 @@
 :root {
   --accent-color: #ff7b51;
+  --song-title-tint-rgb: 255 255 255;
   --accent-light: color-mix(in srgb, var(--accent-color) 20%, black);
   --accent-lighter: color-mix(in srgb, var(--accent-color) 10%, black);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI change that only affects how the song-details tint CSS variable is computed and applied. Main risk is visual regressions in dark mode if luminance detection or color parsing behaves unexpectedly across browsers/themes.
> 
> **Overview**
> Improves song-details album-color tinting by **normalizing very dark extracted colors in dark mode** (luminance-based blend toward white) so title/metadata tints remain readable.
> 
> Moves `--song-title-tint-rgb` to be set/cleared on the shared song-details content container (instead of only the title element), tolerates missing title nodes, and defines a default `--song-title-tint-rgb` value at `:root`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 516c44c31440acccc7b733c9fcfc6adf8d292fef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->