### PR TITLE
Hide Songs relations button on mobile

### DIFF
--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -722,6 +722,10 @@ body {
 }
 
 @media (max-width: 768px) {
+  #btn-song-relations {
+    display: none;
+  }
+
   .songs-controls-row {
     gap: 0.75rem;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- hide the Songs tab `Relations` button on mobile viewports
- keep the button visible on tablet/desktop layouts

## Changes
- added a mobile media-query rule in `cadence/styles.css`:
  - `#btn-song-relations { display: none; }` inside `@media (max-width: 768px)`

## Verification
- confirmed the only code change is the mobile CSS rule for `#btn-song-relations`
- desktop behavior remains unchanged because the rule is scoped to the mobile breakpoint
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afd14924-cf99-4ad4-aa23-b1d03bc8eb34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afd14924-cf99-4ad4-aa23-b1d03bc8eb34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

