### PR TITLE
Fix set song theme hydration and print generated chord charts

### DIFF
--- a/cadence/app.js
+++ b/cadence/app.js
@@ -22368,9 +22368,12 @@ async function openSongDetailsModal(song, selectedKey = null, setSongContext = n
 
   title.textContent = "Song Details";
 
-  // Fetch song with keys and resources
+  // Fetch full song details when partial set-song payloads are missing fields.
+  // Set-song queries can include keys/resources but omit themes, which breaks
+  // related-song theme matching if we don't hydrate here.
   let songWithResources = song;
-  if (!song.song_resources || !song.song_keys) {
+  const hasThemeList = Array.isArray(song?.themes);
+  if (!song.song_resources || !song.song_keys || !hasThemeList) {
     const { data } = await supabase
       .from("songs")
       .select(`

--- a/cadence/app.js
+++ b/cadence/app.js
@@ -27445,6 +27445,63 @@ function buildPrintSetResourceKey(songId, resourceId) {
   return `${songId}:${resourceId}`;
 }
 
+function buildGeneratedPrintSetChordChartResources(song, setKeys = []) {
+  if (!song?.id) return [];
+  const songResources = Array.isArray(song.song_resources) ? song.song_resources : [];
+  const uniqueSetKeys = Array.from(
+    new Set(
+      (setKeys || [])
+        .map((key) => normalizeKeyLabel(key))
+        .filter(Boolean)
+    )
+  );
+  if (!uniqueSetKeys.length) return [];
+
+  const generalNumberChart = songResources.find((resource) => {
+    if (resource?.type !== "chart") return false;
+    if (normalizeKeyLabel(resource?.key || "")) return false;
+    const chartType = resource.chart_content?.chart_type || resource.chart_type || "chord";
+    return chartType === "number";
+  });
+  if (!generalNumberChart) return [];
+
+  const sourceDoc = generalNumberChart.chart_content?.doc || generalNumberChart.doc || null;
+  if (!sourceDoc) return [];
+
+  const existingChordChartKeys = new Set();
+  songResources.forEach((resource) => {
+    if (resource?.type !== "chart") return;
+    const chartType = resource.chart_content?.chart_type || resource.chart_type || "chord";
+    if (chartType !== "chord") return;
+    const resourceKey = normalizeKeyLabel(resource?.key || "").toLowerCase();
+    if (!resourceKey) return;
+    existingChordChartKeys.add(resourceKey);
+  });
+
+  const baseOrder = Number(generalNumberChart.display_order);
+  const generatedOrder = Number.isFinite(baseOrder) ? baseOrder + 0.001 : -1;
+
+  return uniqueSetKeys
+    .filter((key) => parseKeyToPitchClass(key))
+    .filter((key) => !existingChordChartKeys.has(key.toLowerCase()))
+    .map((key) => ({
+      ...generalNumberChart,
+      id: `generated-number:${song.id}:${key.toLowerCase()}`,
+      key,
+      display_order: generatedOrder,
+      generatedFromNumber: true,
+      sourceDoc,
+      targetKey: key,
+      chart_content: {
+        ...(generalNumberChart.chart_content || {}),
+        chart_type: "chord",
+        scope: "key",
+        songKey: key,
+        doc: null,
+      },
+    }));
+}
+
 function buildPrintSetSectionKey(setSongId) {
   return `section:${setSongId}`;
 }
@@ -27466,10 +27523,16 @@ function buildPrintSetResourceEntry(song, resource) {
   const songTitle = song.title || "Untitled";
   const key = buildPrintSetResourceKey(songId, resource.id);
   const chartType = resource.chart_content?.chart_type || resource.chart_type || "chord";
+  const generatedFromNumber = !!resource.generatedFromNumber;
+  const targetKey = normalizeKeyLabel(resource.targetKey || resource.key || "");
 
   let title = resource.title || resource.file_name || resource.url || "Resource";
   if (resource.type === "chart") {
-    title = chartType === "number" ? "Number Chart" : "Chord Chart";
+    if (chartType === "number") {
+      title = "Number Chart";
+    } else {
+      title = generatedFromNumber ? "Chord Chart (Generated)" : "Chord Chart";
+    }
   }
 
   const metaParts = [];
@@ -27478,6 +27541,9 @@ function buildPrintSetResourceEntry(song, resource) {
     const typeLabel = chartType === "number" ? "Number chart" : "Chord chart";
     metaParts.push({ text: scopeLabel, kind: "key" });
     metaParts.push({ text: typeLabel, kind: "chart-type" });
+    if (generatedFromNumber) {
+      metaParts.push({ text: "Auto-generated", kind: "state" });
+    }
   } else if (resource.key) {
     metaParts.push({ text: `Key: ${resource.key}`, kind: "key" });
   }
@@ -27501,6 +27567,9 @@ function buildPrintSetResourceEntry(song, resource) {
     subtitle,
     metaParts,
     displayOrder: resource.display_order ?? Number.POSITIVE_INFINITY,
+    generatedFromNumber,
+    sourceDoc: resource.sourceDoc || resource.numberSourceDoc || null,
+    targetKey: targetKey || null,
   };
 }
 
@@ -27757,7 +27826,13 @@ async function renderPrintSetResources({
       bodyEl.className = "print-resource-body";
 
       if (entry.kind === "chart") {
-        const chartDoc = entry.resource?.chart_content?.doc || entry.resource?.doc;
+        let chartDoc = entry.resource?.chart_content?.doc || entry.resource?.doc;
+        if (!chartDoc && entry.generatedFromNumber && entry.sourceDoc && entry.targetKey) {
+          chartDoc = generateChordDocFromNumberDoc(entry.sourceDoc, entry.targetKey, {
+            songTitle: songTitle || entry.sourceDoc?.title || "Chord Chart",
+            layout: entry.resource?.chart_content?.layout || entry.resource?.layout || entry.sourceDoc?.settings?.layout || "one_column",
+          });
+        }
         if (!chartDoc) {
           const err = document.createElement("div");
           err.className = "print-resource-error";
@@ -28294,7 +28369,11 @@ function renderPrintSetResourceList(set) {
     header.appendChild(titleWrap);
     group.appendChild(header);
 
-    const printableResources = (song.song_resources || [])
+    const setKeysForSong = explicitKeys && explicitKeys.size
+      ? Array.from(explicitKeys)
+      : fallbackKeys;
+    const generatedChordCharts = buildGeneratedPrintSetChordChartResources(song, setKeysForSong);
+    const printableResources = [...(song.song_resources || []), ...generatedChordCharts]
       .filter(res => getPrintableResourceKind(res))
       .sort((a, b) => (a.display_order ?? Number.POSITIVE_INFINITY) - (b.display_order ?? Number.POSITIVE_INFINITY));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix song-details hydration so songs opened from a set also fetch missing `themes`, restoring theme-based related-song matches
- add synthetic print-resource entries for key-specific chord charts generated from a song's general number chart when the set uses that key
- display these generated entries in the Print Set modal resource list with clear metadata (`Chord Chart (Generated)`, `Auto-generated`)
- update print rendering so generated entries build chord docs on-demand via number-chart transposition for the target key

## Validation
- `node --check cadence/app.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b68a779a-b140-4dda-af6e-3e3e65c616f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b68a779a-b140-4dda-af6e-3e3e65c616f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

