### PR TITLE
Scope album cover hover motion to song details modal

### DIFF
--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -3964,8 +3964,8 @@ textarea {
   transition-delay: 0s;
 }
 
-.song-album-art-container:hover .song-album-art-vinyl,
-.song-album-art-container:focus-within .song-album-art-vinyl {
+#song-details-modal .song-album-art-container:hover .song-album-art-vinyl,
+#song-details-modal .song-album-art-container:focus-within .song-album-art-vinyl {
   transition-delay: 90ms;
 }
 
@@ -3983,7 +3983,7 @@ textarea {
   }
 }
 
-.song-album-art-container:hover {
+#song-details-modal .song-album-art-container:hover {
   --album-art-shift-x: -42px;
   --album-art-shift-y: 3px;
   --album-art-tilt: -4deg;
@@ -3992,7 +3992,7 @@ textarea {
   --vinyl-tilt: -0.7deg;
 }
 
-.song-album-art-container:hover .album-art-overlay-controls {
+#song-details-modal .song-album-art-container:hover .album-art-overlay-controls {
   opacity: 1 !important;
   pointer-events: auto;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scoped song album art hover-driven transform variables to `#song-details-modal` context
- scoped modal-only hover affordances (vinyl delay and overlay controls reveal) to the song details modal
- prevents `::before`/`::after` movement on album covers reused in the “Add Song from catalog” card

## Testing
- CSS selector audit: verified hover/focus-within selectors for `.song-album-art-container` now only apply under `#song-details-modal`
- no automated test suite was run for this CSS-only change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0e16da9-f236-4500-933e-b67555593c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0e16da9-f236-4500-933e-b67555593c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

