### PR TITLE
Fix vinyl rotation snapping when click track pauses

### DIFF
--- a/cadence/app.js
+++ b/cadence/app.js
@@ -31749,7 +31749,17 @@ function updateClickTrackButtons() {
   const modalClickTrackBtn = songDetailsModal?.querySelector(".song-click-track .click-track-btn");
   const modalVinyl = songDetailsModal?.querySelector(".song-album-art-vinyl");
   const shouldSpinVinyl = !!modalVinyl && !!modalClickTrackBtn?.classList.contains("active");
-  modalVinyl?.classList.toggle("is-spinning", shouldSpinVinyl);
+  if (modalVinyl) {
+    if (shouldSpinVinyl) {
+      modalVinyl.classList.add("is-spinning");
+      modalVinyl.classList.remove("is-paused");
+    } else if (modalVinyl.classList.contains("is-spinning")) {
+      // Keep the current rotation frame when click track is paused.
+      modalVinyl.classList.add("is-paused");
+    } else {
+      modalVinyl.classList.remove("is-paused");
+    }
+  }
 }
 
 // Custom Searchable Dropdown Component

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -3973,6 +3973,10 @@ textarea {
   animation: songDetailsVinylSpin 8s linear infinite;
 }
 
+.song-album-art-vinyl.is-spinning.is-paused {
+  animation-play-state: paused;
+}
+
 @keyframes songDetailsVinylSpin {
   from {
     transform: translate(calc(-50% + var(--vinyl-shift-x)), calc(-50% + var(--vinyl-shift-y))) rotate(var(--vinyl-tilt));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update click-track UI sync logic so the song details vinyl keeps its active spin animation class after stopping
- add a paused state class when click track is stopped so the vinyl freezes at its current rotation instead of resetting to its base transform
- resume spinning from the frozen frame when click track starts again by removing the paused state

## Testing
- not run (UI behavior change only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53a644f0-770a-4333-b742-27934c8cd6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53a644f0-770a-4333-b742-27934c8cd6f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

