### PR TITLE
Cadence follow-up: BPM severity colors and 6/8↔3/4 heads-up visibility

### DIFF
--- a/cadence/app.js
+++ b/cadence/app.js
@@ -15184,15 +15184,18 @@ function getTagTransitionHeadsUp(setSong, set = state.selectedSet) {
   const parentTimeSignature = String(parentSetSong.song?.time_signature || "").trim();
   const tagTimeSignature = String(setSong.song?.time_signature || "").trim();
   const hasEquivalentTimeSignature = areEquivalentTimeSignatures(parentTimeSignature, tagTimeSignature);
-  const hasTimeSignatureChange = Boolean(
+  const hasDifferentTimeSignatureText = Boolean(
     parentTimeSignature &&
     tagTimeSignature &&
-    parentTimeSignature.toLowerCase() !== tagTimeSignature.toLowerCase() &&
-    !hasEquivalentTimeSignature
+    parentTimeSignature.toLowerCase() !== tagTimeSignature.toLowerCase()
   );
   const hasPulseCompatibleTimeSignatureSwap =
-    hasTimeSignatureChange &&
+    hasDifferentTimeSignatureText &&
     isPulseCompatibleTimeSignatureSwap(parentTimeSignature, tagTimeSignature);
+  const hasTimeSignatureChange = Boolean(
+    hasDifferentTimeSignatureText &&
+    (!hasEquivalentTimeSignature || hasPulseCompatibleTimeSignatureSwap)
+  );
   const countsTowardDifficultyTimeSignatureChange =
     hasTimeSignatureChange && !hasPulseCompatibleTimeSignatureSwap;
 

--- a/cadence/app.js
+++ b/cadence/app.js
@@ -11508,9 +11508,7 @@ function renderSetDetailSongs(set, animate = false) {
 
               const icon = document.createElement("i");
               if (item.kind === "bpm") {
-                icon.className = item.tone === "loss" ? "fa-solid fa-arrow-down" : "fa-solid fa-arrow-up";
-              } else if (item.kind === "tempo-ratio") {
-                icon.className = "fa-solid fa-calculator";
+                icon.className = item.direction === "loss" ? "fa-solid fa-arrow-down" : "fa-solid fa-arrow-up";
               } else if (item.kind === "time-signature") {
                 icon.className = "fa-solid fa-wave-square";
               } else if (item.kind === "key") {
@@ -11524,10 +11522,14 @@ function renderSetDetailSongs(set, animate = false) {
               label.textContent = item.label;
 
               itemText.appendChild(icon);
-              if (item.label) {
-                itemText.appendChild(label);
-              } else {
-                itemText.classList.add("icon-only");
+              itemText.appendChild(label);
+
+              if (item.kind === "bpm" && item.showTempoRatioIcon) {
+                const ratioIcon = document.createElement("i");
+                ratioIcon.className = "fa-solid fa-calculator tempo-ratio-inline-icon";
+                ratioIcon.setAttribute("aria-hidden", "true");
+                itemText.classList.add("has-inline-calculator");
+                itemText.appendChild(ratioIcon);
               }
               headsUpRow.appendChild(itemText);
             });
@@ -15138,11 +15140,32 @@ function getTempoRatioHint(parentBpm, nextBpm) {
 
   const isHalfTime = halfDistance <= doubleDistance;
   return {
-    ratio,
+    ratio: isHalfTime ? ratio * 2 : ratio / 2,
     badgeLabel: "",
     reasonLabel: isHalfTime ? "half-time" : "double-time",
     explanation: `Tempo lands near a ${isHalfTime ? "half-time" : "double-time"} feel (${formatTransitionMetricNumber(parentBpm)} -> ${formatTransitionMetricNumber(nextBpm)} BPM).`
   };
+}
+
+function getTempoContinuityScore(parentBpm, nextBpm, tempoRatioHint) {
+  if (!Number.isFinite(parentBpm) || !Number.isFinite(nextBpm) || parentBpm <= 0 || nextBpm <= 0) {
+    return null;
+  }
+
+  const rawRatio = nextBpm / parentBpm;
+  const nearHalfOrDoubleRatio = tempoRatioHint ? tempoRatioHint.ratio : null;
+  const normalizedRatio = Number.isFinite(nearHalfOrDoubleRatio) ? nearHalfOrDoubleRatio : rawRatio;
+  return Math.abs(normalizedRatio - 1);
+}
+
+function getBpmTransitionSeverity(parentBpm, nextBpm, tempoRatioHint) {
+  const continuityScore = getTempoContinuityScore(parentBpm, nextBpm, tempoRatioHint);
+  if (!Number.isFinite(continuityScore)) return 0;
+  if (continuityScore <= 0.08) return 0;
+  if (continuityScore <= 0.16) return 1;
+  if (continuityScore <= 0.26) return 2;
+  if (continuityScore <= 0.4) return 3;
+  return 4;
 }
 
 function getTagTransitionHeadsUp(setSong, set = state.selectedSet) {
@@ -15184,19 +15207,15 @@ function getTagTransitionHeadsUp(setSong, set = state.selectedSet) {
   const items = [];
   if (hasBpmChange) {
     const direction = bpmDelta > 0 ? "gain" : "loss";
+    const bpmSeverity = getBpmTransitionSeverity(parentBpm, tagBpm, tempoRatioHint);
     items.push({
       kind: "bpm",
-      tone: direction,
-      label: `${bpmDelta > 0 ? "+" : "-"}${formatTransitionMetricNumber(Math.abs(bpmDelta))} BPM`
+      direction,
+      tone: `bpm-severity-${bpmSeverity}`,
+      showTempoRatioIcon: Boolean(tempoRatioHint),
+      label: `${bpmDelta > 0 ? "+" : "-"}${formatTransitionMetricNumber(Math.abs(bpmDelta))} BPM`,
+      explanation: tempoRatioHint ? tempoRatioHint.explanation : ""
     });
-    if (tempoRatioHint) {
-      items.push({
-        kind: "tempo-ratio",
-        tone: "tempo-ratio",
-        label: tempoRatioHint.badgeLabel,
-        explanation: tempoRatioHint.explanation
-      });
-    }
   }
   if (hasTimeSignatureChange) {
     items.push({

--- a/cadence/styles.css
+++ b/cadence/styles.css
@@ -2089,6 +2089,14 @@ ul.song-resource-usage-list {
   font-size: 0.82em;
 }
 
+.set-song-transition-item.has-inline-calculator {
+  gap: 0.22rem;
+}
+
+.set-song-transition-item .tempo-ratio-inline-icon {
+  font-size: 0.9em;
+}
+
 .set-song-transition-item.icon-only {
   gap: 0;
 }
@@ -2097,20 +2105,28 @@ ul.song-resource-usage-list {
   font-size: 0.95em;
 }
 
-.set-song-transition-item.gain {
-  color: color-mix(in srgb, #15803d 76%, var(--text-primary));
+.set-song-transition-item.bpm-severity-0 {
+  color: var(--text-secondary);
 }
 
-.set-song-transition-item.loss {
-  color: color-mix(in srgb, #b91c1c 76%, var(--text-primary));
+.set-song-transition-item.bpm-severity-1 {
+  color: color-mix(in srgb, #dc2626 28%, var(--text-primary));
+}
+
+.set-song-transition-item.bpm-severity-2 {
+  color: color-mix(in srgb, #dc2626 50%, var(--text-primary));
+}
+
+.set-song-transition-item.bpm-severity-3 {
+  color: color-mix(in srgb, #dc2626 72%, var(--text-primary));
+}
+
+.set-song-transition-item.bpm-severity-4 {
+  color: color-mix(in srgb, #991b1b 84%, var(--text-primary));
 }
 
 .set-song-transition-item.compatible {
   color: color-mix(in srgb, #0f766e 74%, var(--text-primary));
-}
-
-.set-song-transition-item.tempo-ratio {
-  color: color-mix(in srgb, #7c3aed 74%, var(--text-primary));
 }
 
 .set-song-transition-item.difficult {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move the calculator hint inline with the BPM transition value so it appears immediately next to the BPM text (no separate gapped chip)
- change BPM transition coloring to a severity scale:
  - near same tempo or near half/double feel uses normal text color
  - progressively stronger red tones are used as tempo continuity gets worse
- fix time-signature heads-up rendering so `6/8 > 3/4` (and reverse) always shows visually even when treated as pulse-compatible
- keep pulse-compatible `6/8 ↔ 3/4` excluded from difficult-transition scoring while still visible in heads-up

## Testing
- `node --check cadence/app.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f85c85d-c005-4261-a437-7d999ab8ce64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f85c85d-c005-4261-a437-7d999ab8ce64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

